### PR TITLE
Fixed bson arguement error and changed mongo and bson version

### DIFF
--- a/lib/logstash/outputs/bson/big_decimal.rb
+++ b/lib/logstash/outputs/bson/big_decimal.rb
@@ -33,7 +33,7 @@ module BSON
     #   1.221311.to_bson
     # @return [ String ] The encoded string.
     # @see http://bsonspec.org/#/specification
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_bytes([ self ].pack(PACK))	
     end
 

--- a/lib/logstash/outputs/bson/logstash_event.rb
+++ b/lib/logstash/outputs/bson/logstash_event.rb
@@ -30,7 +30,7 @@ module BSON
     #   Event.new("field" => "value").to_bson
     # @return [ String ] The encoded string.
     # @see http://bsonspec.org/#/specification
-     def to_bson(buffer = ByteBuffer.new)
+     def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       position = buffer.length
       buffer.put_int32(0)
       to_hash.each do |field, value|

--- a/lib/logstash/outputs/bson/logstash_timestamp.rb
+++ b/lib/logstash/outputs/bson/logstash_timestamp.rb
@@ -25,7 +25,7 @@ module BSON
     # A time is type 0x09 in the BSON spec.
     BSON_TYPE = 9.chr.force_encoding(BINARY).freeze
 
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       time.to_bson(buffer)
     end
 

--- a/logstash-output-mongodb.gemspec
+++ b/logstash-output-mongodb.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-mongodb'
-  s.version         = '3.1.6'
-  s.licenses        = ['Apache License (2.0)']
+  s.version         = '3.1.7'
+  s.licenses        = ['Apache-2.0']
   s.summary         = "Writes events to MongoDB"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
@@ -21,7 +21,8 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'mongo', '~> 2.6'
+  s.add_runtime_dependency 'mongo', '~> 2.11.4'
+  s.add_runtime_dependency 'bson', '~> 4.8.2'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Integrated the changes of [Ryan Morrison](https://github.com/rmmorrison) (https://github.com/logstash-plugins/logstash-output-mongodb/pull/66)

And upgraded mongo's ruby driver version and downgraded bson's ruby driver. Bson's downgrade was to fix (https://jira.mongodb.org/browse/RUBY-2146) because even 4.9.4 had the same serialisation error.

Mongo's driver upgrade was to fix authentication error's I was facing while using Mongo URI connection